### PR TITLE
Change port so that Heroku can recognise it

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,6 @@ var app = function(req, res){
   router(req,res);
 };
 
-var port = 4000;
+var port = process.env.PORT || 4000;
 var server = http.createServer(app).listen(port);
 console.log(`Server is listening on port: ${port}`);


### PR DESCRIPTION
Heroku doesn't recognise var port = 4000 so we have added var port = process.env.PORT || 4000
Relates #23